### PR TITLE
Add important to tinymce editor fullscreen width

### DIFF
--- a/app/stylesheets/tinymce/skins/ui/alchemy/skin.scss
+++ b/app/stylesheets/tinymce/skins/ui/alchemy/skin.scss
@@ -2470,7 +2470,7 @@ body.tox-dialog__disable-scroll {
   overscroll-behavior: none;
   padding: 0;
   touch-action: pinch-zoom;
-  width: 100%;
+  width: 100% !important;
 }
 
 .tox.tox-tinymce.tox-fullscreen .tox-statusbar__resize-handle {


### PR DESCRIPTION
## What is this pull request for?

Prevents content from overflowing outside viewport in tinymce editor in fullscreen mode.

Since tinymce applies the viewport width directly to the fullscreen div element itself, the element width style currently has more specificity. This PR overrides it by declaring the width defined in skin.scss as !important.

Alchemy-csm version used is 7.4.

The PR #3097 says it has solved this problem, but it seems to be still persisting.

The video shown in PR #3097 doesn't seem to have this issue, so I would like to know if there is something wrong on my end. (For example, my local assets are outdated?)

If this issue is local to me, please kindly let me know where to look to fix this.
Otherwise, I believe this PR solves the problem.

Closes #2733

### Screenshots

**Fullscreen editor element (style is defined directly on the element)**
<img width="674" alt="Screenshot 2025-02-28 at 1 58 13 PM" src="https://github.com/user-attachments/assets/0c009421-cf80-4ad3-8f06-610a202c924a" />

**Before**
<img width="835" alt="Screenshot 2025-02-28 at 1 55 22 PM" src="https://github.com/user-attachments/assets/f8964e39-bb9b-4eb1-9360-c9f9044661a2" />

**After**
<img width="835" alt="Screenshot 2025-02-28 at 1 55 50 PM" src="https://github.com/user-attachments/assets/bdf31a62-84af-4083-b2f2-88444beab884" />

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [ ] I have added a detailed description into each commit message 
- [ ] I have added tests to cover this change
